### PR TITLE
adding Docker support

### DIFF
--- a/snowfall-lib/system/virtual-systems.nix
+++ b/snowfall-lib/system/virtual-systems.nix
@@ -7,6 +7,7 @@
   "amazon"
   "azure"
   "cloudstack"
+  "docker"
   "do"
   "gce"
   "hyperv"


### PR DESCRIPTION
Per [this issue](https://github.com/snowfallorg/lib/issues/19) I added `docker` above `do` in order to make it available as a system that Snowfall could build. Tested locally with your dotfiles (cause you have a `do` system) and mine (with `docker`) and your suggestion about putting `docker` above `do` seems to have worked. 