### PR TITLE
fix: use home-manager imports for user home configuration

### DIFF
--- a/snowfall-lib/home/default.nix
+++ b/snowfall-lib/home/default.nix
@@ -328,7 +328,6 @@ in
                     enable = true;
                     name = mkDefault user-name;
                   };
-                  home.stateVersion = "22.11";
                 };
 
                 home-manager = {

--- a/snowfall-lib/home/default.nix
+++ b/snowfall-lib/home/default.nix
@@ -315,6 +315,8 @@ in
                     =============
                   '')
                     user-option;
+
+              home-config = mkAliasAndWrapDefinitions wrap-user-options options.snowfallorg.user;
             in
             {
               _file = "virtual:snowfallorg/home/user/${name}";
@@ -326,13 +328,14 @@ in
                     enable = true;
                     name = mkDefault user-name;
                   };
+                  home.stateVersion = "22.11";
                 };
 
                 home-manager = {
-                  users.${user-name} = mkAliasAndWrapDefinitions wrap-user-options options.snowfallorg.user;
-
-                  # sharedModules = other-modules ++ optional config.snowfallorg.user.${user-name}.home.enable wrapped-user-module;
-                  sharedModules = other-modules ++ optional config.snowfallorg.user.${user-name}.home.enable user-module;
+                  users.${user-name} = mkIf config.snowfallorg.user.${user-name}.home.enable ({ pkgs, ... }: {
+                    imports = (home-config.imports or [ ]) ++ other-modules ++ [user-module];
+                    config = home-config;
+                  });
 
                   # NOTE: Without this home-manager will instead create its own package set which won't contain the same config and
                   # user-defined packages/overlays as the flake's nixpkgs channel.
@@ -347,7 +350,6 @@ in
         extra-special-args-module
         snowfall-user-home-module
       ]
-      ++ (users.modules or [ ])
       ++ shared-modules
       ++ system-modules;
   };


### PR DESCRIPTION
This one was a long time coming. We had #34 crop up a little while ago and it is, to some extent, an issue that I have run into as well and only really managed to work around on my end due to relying mostly on modules at the system level. Home-Manager support was originally implemented similarly to this using a function to declare the user's config, but that hit several roadblocks:

- Not allowing config from the system level using `home-manager.users.${user}`
- Missing module args
- Trouble dynamically remapping attributes from the user module

However, I believe these have now all been rectified.

- We now have the system-level `snowfallorg.user` options and accompanying magic aliasing
- It was discovered that Home-Manager only passes args like "pkgs" if they are defined in the function's arg attribute set
- Remapping things manually was mostly a lost cause and we should've tried to make native imports work instead since they operate on modules as a whole

Fixes #34

BREAKING CHANGE

This commit introduces a breaking change in the form of replacing `home-manager.users.${user}` with a function where it was previously an attribute set. This means any system-level modules that set `home-manager.users.${user}.*` will now throw an error. Instead, these modules need to be refactored to use `snowfallorg.user.${user}.home.config.*`.