### PR TITLE
fix: allow modules modules that are not functions

### DIFF
--- a/snowfall-lib/module/default.nix
+++ b/snowfall-lib/module/default.nix
@@ -5,7 +5,7 @@
   snowfall-config,
 }: let
   inherit (builtins) baseNameOf;
-  inherit (core-inputs.nixpkgs.lib) assertMsg foldl mapAttrs hasPrefix;
+  inherit (core-inputs.nixpkgs.lib) foldl mapAttrs hasPrefix isFunction;
 
   user-modules-root = snowfall-lib.fs.get-snowfall-file "modules";
 in {
@@ -67,7 +67,11 @@ in {
 
                 inputs = snowfall-lib.flake.without-src user-inputs;
               };
-            user-module = import metadata.path modified-args;
+            imported-user-module = import metadata.path;
+            user-module =
+              if isFunction imported-user-module
+              then imported-user-module modified-args
+              else imported-user-module;
           in
             user-module // {_file = metadata.path;};
         };


### PR DESCRIPTION
This fix allows such modules to exist:
```nix
{
  abc = "123";
}
```
Before, I had to do:
```nix
{...}: {
  abc = "123";
}
```
And if I didn't, this error was raised:
```
         error: attempt to call something which is not a function but a set                                                                                                                                                             
                                                                                                                                                                                                                                        
         at /nix/store/dkp41micvz3v8ba4rlmln6dvbh0yiv5a-j9c415rh87wp12q9a9g2xc7kjqnyg147-source/snowfall-lib/module/default.nix:76:31:                                                                                                  
                                                                                                                                                                                                                                        
             75|                 };                                                                                                                                                                                                     
             76|                 user-module = import metadata.path modified-args;                                                                                                                                                      
               |                               ^                                                                                                                                                                                        
             77|               in     
```