### PR TITLE
Updates flake-utils-plus.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,11 +39,11 @@
         "flake-utils": "flake-utils"
       },
       "locked": {
-        "lastModified": 1696331477,
-        "narHash": "sha256-YkbRa/1wQWdWkVJ01JvV+75KIdM37UErqKgTf0L54Fk=",
+        "lastModified": 1715533576,
+        "narHash": "sha256-fT4ppWeCJ0uR300EH3i7kmgRZnAVxrH+XtK09jQWihk=",
         "owner": "gytis-ivaskevicius",
         "repo": "flake-utils-plus",
-        "rev": "bfc53579db89de750b25b0c5e7af299e0c06d7d3",
+        "rev": "3542fe9126dc492e53ddd252bb0260fe035f2c0f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Ran `nix flake update flake-utils-plus` to pull in fixes for gytis-ivaskevicius/flake-utils-plus#145 which were resolved by gytis-ivaskevicius/flake-utils-plus#146

Closes snowfallorg/lib#80
Fixes snowfallorg/lib#76 (which was already closed but not actually fixed)