### PR TITLE
fix(templates): remove leftover debugging statements

### DIFF
--- a/snowfall-lib/template/default.nix
+++ b/snowfall-lib/template/default.nix
@@ -37,8 +37,6 @@ in {
         templates
         // {
           ${metadata.name} =
-            (builtins.trace "name: ${metadata.name}")
-            (builtins.trace "path: ${metadata.path}")
             (overrides.${metadata.name} or {})
             // {
               inherit (metadata) path;


### PR DESCRIPTION
These shouldn't be here: https://github.com/snowfallorg/lib/commit/b2e636407591bfe7a1f9a4ff50e282ed51ce7b59#r142358736
