### PR TITLE
fix: make system-lib imports use namespaces

### DIFF
--- a/snowfall-lib/internal/default.nix
+++ b/snowfall-lib/internal/default.nix
@@ -30,7 +30,7 @@
         namespace = snowfall-config.namespace;
         lib = snowfall-lib.attrs.merge-shallow [
           base-lib
-          {internal = user-lib;}
+          {"${snowfall-config.namespace}" = user-lib;}
         ];
       };
       libs =


### PR DESCRIPTION
Previously when you accessed stuff on your lib via snowfall-lib's internal system-lib (e.g. with lib.snowfall.internal.system-lib.my-namespace.my-lib-function) the lib which is passed to *your* lib used hardcoded the "internal" name

This makes lib functions in your flake's lib break if they use other lib functions in your flake's lib