### PR TITLE
fix: Correct simple typo in definition`os-user-home` in home module 

### DIFF
--- a/modules/home/user/default.nix
+++ b/modules/home/user/default.nix
@@ -11,7 +11,7 @@ inputs @ {
 
   # NOTE: The module system chokes if it finds `osConfig` named in the module arguments
   # when being used in standalone home-manager. To remedy this, we have to refer to the arguments set directly.
-  os-user-home = inputs.osConfig.users.users.${cfg.name}.home or null;
+  os-user-home = inputs.osConfig.users.users.${cfg.user.name}.home or null;
 
   has-user-name = (cfg.user.name or null) != null;
 


### PR DESCRIPTION
I hope this is the right fix, but I'm kinda surprised no one else has spotted this problem first, since I believe it prevents building if the user doesn't specify an explicit home directory path. 