### PR TITLE
feat: add support for formatter

### DIFF
--- a/snowfall-lib/flake/default.nix
+++ b/snowfall-lib/flake/default.nix
@@ -150,9 +150,12 @@ in rec {
         overrides = (full-flake-options.checks or {}) // (user-outputs.checks or {});
         alias = alias.checks or {};
       };
+      formatter = snowfall-lib.formatter.create-formatter {
+        inherit channels;
+      };
 
       outputs = {
-        inherit packages checks;
+        inherit packages checks formatter;
 
         devShells = shells;
       };

--- a/snowfall-lib/formatter/default.nix
+++ b/snowfall-lib/formatter/default.nix
@@ -1,0 +1,53 @@
+{
+  core-inputs,
+  user-inputs,
+  snowfall-lib,
+  snowfall-config,
+}: let
+  inherit (core-inputs.flake-utils-plus.lib) filterPackages;
+  inherit (core-inputs.nixpkgs.lib) assertMsg foldl mapAttrs callPackageWith;
+
+  user-formatters-root = snowfall-lib.fs.get-snowfall-file "formatter";
+in {
+  formatter = {
+    ## Create flake output packages.
+    ## Example Usage:
+    ## ```nix
+    ## create-formatter { inherit channels; src = ./my-formatters; }
+    ## ```
+    ## Result:
+    ## ```nix
+    ## <<derivation ...>>
+    ## ```
+    #@ Attrs -> Drv
+    create-formatter = {
+      channels,
+      src ? user-formatters-root,
+      pkgs ? channels.nixpkgs,
+    }: let
+      user-formatters = snowfall-lib.fs.get-default-nix-files src;
+      create-formatter-metadata = formatter: let
+        extra-inputs =
+          pkgs
+          // {
+            inherit channels;
+            lib = snowfall-lib.internal.system-lib;
+            inputs = snowfall-lib.flake.without-src user-inputs;
+            namespace = snowfall-config.namespace;
+          };
+      in {
+        name = "formatter";
+        drv = callPackageWith extra-inputs formatter {};
+      };
+      formatters-metadata = builtins.map create-formatter-metadata user-formatters;
+      merge-formatters = formatters: metadata:
+        formatters
+        // {
+          ${metadata.name} = metadata.drv;
+        };
+      formatters-without-aliases = foldl merge-formatters {} formatters-metadata;
+      formatters = formatters-without-aliases;
+    in
+      (filterPackages pkgs.system formatters).formatter;
+  };
+}


### PR DESCRIPTION
Since the nix flake outputs schema allows us to specify a formatter, I figured it makes sense to support formatter in snowfall-lib (without having to use outputs-builder).

The schema for formatter is similar to checks, devShells, etc but currently only allows for a single option per-system. With this in mind, I think a single derivation (dependent on `system`) specified at `formatter/default.nix` would fit well with the current snowfall-lib structure.

Since there is only one formatter, `alias` is not applicable here. In theory `overrides` could be implemented but would require setting priority between `full-flake-options` and `user-outputs` so I have skipped this for now.

The implementation of `create-formatter` is based on `create-checks` and `create-shells` so has some redundant steps but provides a basic proof of concept. 