### PR TITLE
Add support for the same username across multiple targets

### DIFF
--- a/snowfall-lib/flake/default.nix
+++ b/snowfall-lib/flake/default.nix
@@ -4,7 +4,7 @@
   snowfall-lib,
   snowfall-config,
 }: let
-  inherit (core-inputs.nixpkgs.lib) assertMsg foldl filterAttrs const;
+  inherit (core-inputs.nixpkgs.lib) assertMsg foldl filterAttrs const mapAttrs mapAttrs' hasSuffix removeSuffix nameValuePair;
 in rec {
   flake = rec {
     ## Remove the `self` attribute from an attribute set.
@@ -197,5 +197,24 @@ in rec {
         inherit overlays;
       };
   in
-    flake-outputs;
+    flake-outputs // {
+      packages = flake-outputs.packages // (builtins.listToAttrs (
+          builtins.map (system: {
+            name = system;
+            value = flake-outputs.packages.${system} // {
+              homeConfigurations =
+                let
+                  homeNames = filterAttrs (_: home: home.system == system) homes;
+                  homeConfigurations = mapAttrs (home-name: _: flake-outputs.homeConfigurations.${home-name}) homeNames;
+                  renamedHomeConfigurations = mapAttrs' (name: value:
+                    if hasSuffix "@${system}" name
+                    then nameValuePair (removeSuffix "@${system}" name) value 
+                    else nameValuePair name value
+                  ) homeConfigurations;
+                in
+                  renamedHomeConfigurations;
+            };
+          }) core-inputs.flake-utils-plus.lib.defaultSystems
+        ));
+    };
 }


### PR DESCRIPTION
Hopefully fixes #124
In the [v3 migration docs](https://snowfall.org/guides/lib/migration/v3/#target-wide-home-manager), it says that a file containing home manager configuration at `homes/<target>/ <username>/default.nix` will make the corresponding homeConfiguration available as `outputs.homeConfigurations."<username>@<target>"`. In reality, it is available at `outputs.homeConfigurations.<username>`. It seems that `x86_64-linux` has precedence over `aarch64-darwin`, so when I have both `homes/aarch64-darwin/james/default.nix` and `homes/x86_64-linux/james/default.nix`, only the `x86_64-linux` configuration actually makes it to the `outputs` (and importantly, `darwinConfigurations.myMachine.home-manager.users`).

This PR brings the `outputs.homeConfigurations` behaviour in line with what the migration guide says is the behaviour. It also uses these new names when choosing which homes to include in nixos and darwin configurations. 
To maintain maximum possible compatibility for users who `home-manager switch --flake .`, I've also added `packages.<target>.homeConfigurations` with only the `homeConfigurations` for that `target`. Since home-manager looks at `homeConfigurations`, `packages.<target>.homeConfigurations` and `legacyPackages.<target>.homeConfigurations` when running `home-manager switch --flake`, this means that assuming the switch worked before, it should do the same thing after this PR is merged. 

I'm not the happiest about the changes I've made to `snowfall-lib/flake/default.nix` - I'm sure there's a much nicer way of doing this, but my nix skills aren't there yet.