### PR TITLE
Give `homes` namespace argument

### DIFF
--- a/snowfall-lib/home/default.nix
+++ b/snowfall-lib/home/default.nix
@@ -275,6 +275,7 @@ in {
         config = {
           home-manager.extraSpecialArgs = {
             inherit system target format virtual systems host;
+            inherit (snowfall-config) namespace;
 
             lib = home-lib;
 


### PR DESCRIPTION
Closes #142

Adds `namespace` to `home-manager.extraSpecialArgs`, so files `homes/<target>/<home_name>/default.nix` will get `namespace` as an argument.