### PR TITLE
fix: replace cfg.useUserPackages with home-manager.useUserPackages

### DIFF
--- a/modules/darwin/user/default.nix
+++ b/modules/darwin/user/default.nix
@@ -82,7 +82,7 @@ in {
 
                       config = {
                         submoduleSupport.enable = true;
-                        submoduleSupport.externalPackageInstall = cfg.useUserPackages;
+                        submoduleSupport.externalPackageInstall = config.home-manager.useUserPackages;
 
                         home.username = config.users.users.${name}.name;
                         home.homeDirectory = config.users.users.${name}.home;

--- a/modules/nixos/user/default.nix
+++ b/modules/nixos/user/default.nix
@@ -100,7 +100,7 @@ in {
 
                         config = {
                           submoduleSupport.enable = true;
-                          submoduleSupport.externalPackageInstall = cfg.useUserPackages;
+                          submoduleSupport.externalPackageInstall = config.home-manager.useUserPackages;
 
                           home.username = config.users.users.${name}.name;
                           home.homeDirectory = config.users.users.${name}.home;


### PR DESCRIPTION
Fixes #152

I made the same change to the darwin module, which I assume would be the same problem.