### PR TITLE
Add automatic template description

### DIFF
--- a/snowfall-lib/template/default.nix
+++ b/snowfall-lib/template/default.nix
@@ -3,12 +3,14 @@
   user-inputs,
   snowfall-lib,
   snowfall-config,
-}: let
+}:
+let
   inherit (builtins) baseNameOf;
   inherit (core-inputs.nixpkgs.lib) assertMsg foldl mapAttrs;
 
   user-templates-root = snowfall-lib.fs.get-snowfall-file "templates";
-in {
+in
+{
   template = {
     ## Create flake templates.
     ##
@@ -22,31 +24,35 @@ in {
     ## { another-template = ...; my-template = ...; default = ...; }
     ## ```
     #@ Attrs -> Attrs
-    create-templates = {
-      src ? user-templates-root,
-      overrides ? {},
-      alias ? {},
-    }: let
-      user-templates = snowfall-lib.fs.get-directories src;
-      create-template-metadata = template: {
-        name = builtins.unsafeDiscardStringContext (baseNameOf template);
-        path = template;
-      };
-      templates-metadata = builtins.map create-template-metadata user-templates;
-      merge-templates = templates: metadata:
-        templates
-        // {
-          ${metadata.name} =
-            (overrides.${metadata.name} or {})
-            // {
-              inherit (metadata) path;
-            };
+    create-templates =
+      {
+        src ? user-templates-root,
+        overrides ? { },
+        alias ? { },
+      }:
+      let
+        user-templates = snowfall-lib.fs.get-directories src;
+        create-template-metadata = template: {
+          name = builtins.unsafeDiscardStringContext (baseNameOf template);
+          path = template;
+          inherit (import (template + "/flake.nix")) description;
         };
-      templates-without-aliases = foldl merge-templates {} templates-metadata;
-      aliased-templates = mapAttrs (name: value: templates-without-aliases.${value}) alias;
-      unused-overrides = builtins.removeAttrs overrides (builtins.map (metadata: metadata.name) templates-metadata);
-      templates = templates-without-aliases // aliased-templates // unused-overrides;
-    in
+        templates-metadata = builtins.map create-template-metadata user-templates;
+        merge-templates =
+          templates: metadata:
+          templates
+          // {
+            ${metadata.name} = (overrides.${metadata.name} or { }) // {
+              inherit (metadata) path description;
+            };
+          };
+        templates-without-aliases = foldl merge-templates { } templates-metadata;
+        aliased-templates = mapAttrs (name: value: templates-without-aliases.${value}) alias;
+        unused-overrides = builtins.removeAttrs overrides (
+          builtins.map (metadata: metadata.name) templates-metadata
+        );
+        templates = templates-without-aliases // aliased-templates // unused-overrides;
+      in
       templates;
   };
 }


### PR DESCRIPTION
Currently you need to manually add a description for templates as per the documentation
```nix
templates = {
    my-template.description = "This is my template created with Snowfall Lib!";
};
```

However, it seems easier and more sane to automatically extract the description from `./templates/my-template/flake.nix`'s description field. This is what this PR does, meaning that you no longer need to add the above description manually.