### PR TITLE
Don't overwrite channels options

### DIFF
--- a/snowfall-lib/flake/default.nix
+++ b/snowfall-lib/flake/default.nix
@@ -174,9 +174,13 @@ in rec {
 
         channelsConfig = full-flake-options.channels-config or {};
 
-        channels.nixpkgs.overlaysBuilder = snowfall-lib.overlay.create-overlays-builder {
-          inherit namespace;
-          extra-overlays = full-flake-options.overlays or [];
+        channels = custom-flake-options.channels // {
+          nixpkgs = custom-flake-options.channels.nixpkgs // {
+            overlaysBuilder = snowfall-lib.overlay.create-overlays-builder {
+              inherit namespace;
+              extra-overlays = full-flake-options.overlays or [ ];
+            };
+          };
         };
 
         outputsBuilder = outputs-builder;


### PR DESCRIPTION
Overwrites patches for me, when using `channels.nixpkgs.patches`