### PR TITLE
Update flake deps and fix warning

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -39,32 +39,32 @@
         "flake-utils": "flake-utils"
       },
       "locked": {
-        "lastModified": 1715533576,
-        "narHash": "sha256-fT4ppWeCJ0uR300EH3i7kmgRZnAVxrH+XtK09jQWihk=",
+        "lastModified": 1779563444,
+        "narHash": "sha256-+rEagECcF6BhWfLs8VCkPqsBuxxSSIRxMlgjXj6G8UQ=",
         "owner": "gytis-ivaskevicius",
         "repo": "flake-utils-plus",
-        "rev": "3542fe9126dc492e53ddd252bb0260fe035f2c0f",
+        "rev": "a00f6f51907b5c74d2fde086b10b19d446d15717",
         "type": "github"
       },
       "original": {
         "owner": "gytis-ivaskevicius",
+        "ref": "v1.6.0",
         "repo": "flake-utils-plus",
-        "rev": "3542fe9126dc492e53ddd252bb0260fe035f2c0f",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1716181197,
-        "narHash": "sha256-IXOUlMlt0f5n9BoJ56+CseCLV9aaBDoEygIWV/hnUso=",
+        "lastModified": 1783516781,
+        "narHash": "sha256-ws8l2tNUczcxKgFV4jqZE6dJkAI5vM9GRhPN//GPapM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "461aad7a53142b9f9e2a666c810e86b20f5da76b",
+        "rev": "866dd157fa7e2a95a7ed0cf9ed740a9e11fec428",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "release-23.11",
+        "ref": "release-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,8 @@
   description = "Snowfall Lib";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/release-23.11";
-    # NOTE: `nix flake lock --update-input flake-utils-plus` is currently NOT
-    # giving us the appropriate revision. We need a fix from a recent PR in
-    # FUP, so this revision is being hard coded here for now.
-    flake-utils-plus.url = "github:gytis-ivaskevicius/flake-utils-plus?rev=3542fe9126dc492e53ddd252bb0260fe035f2c0f";
+    nixpkgs.url = "github:nixos/nixpkgs/release-26.05";
+    flake-utils-plus.url = "github:gytis-ivaskevicius/flake-utils-plus?ref=v1.6.0";
 
     flake-compat = {
       url = "github:edolstra/flake-compat";

--- a/snowfall-lib/overlay/default.nix
+++ b/snowfall-lib/overlay/default.nix
@@ -82,7 +82,7 @@ in {
       user-packages-overlay = final: prev: let
         user-packages = snowfall-lib.package.create-packages {
           pkgs = final;
-          channels = channel-systems.${prev.system};
+          channels = channel-systems.${prev.stdenv.hostPlatform.system};
           inherit namespace;
         };
       in
@@ -98,7 +98,7 @@ in {
         overlays: file: let
           name = builtins.unsafeDiscardStringContext (snowfall-lib.path.get-parent-directory file);
           overlay = final: prev: let
-            channels = channel-systems.${prev.system};
+            channels = channel-systems.${prev.stdenv.hostPlatform.system};
             user-overlay = import file (
               # Deprecated: Use `inputs.*` instead of referencing the input name directly.
               user-inputs
@@ -151,10 +151,10 @@ in {
       create-package-overlay = package-overlays: file: let
         name = builtins.unsafeDiscardStringContext (snowfall-lib.path.get-parent-directory file);
         overlay = final: prev: let
-          channels = channel-systems.${prev.system};
+          channels = channel-systems.${prev.stdenv.hostPlatform.system};
           packages = snowfall-lib.package.create-packages {
             inherit namespace;
-            channels = channel-systems.${prev.system};
+            channels = channel-systems.${prev.stdenv.hostPlatform.system};
           };
         in
           if namespace == null


### PR DESCRIPTION
1. Update nixpkgs from 23.11 to 26.05
2. Update flake-utils-plus to v1.6.0 tag
3. Fix warning for using deprecated system entry.